### PR TITLE
Set routing dock widget visibility to hidden when loaded

### DIFF
--- a/qvalhalla/plugin.py
+++ b/qvalhalla/plugin.py
@@ -72,6 +72,7 @@ class ValhallaPlugin:
         # try a dock widget
         self.routing_dock = RoutingDockWidget(self.iface)
         self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.routing_dock)
+        self.routing_dock.setVisible(False)
 
     def unload(self):
         """Unload the user interface."""


### PR DESCRIPTION
dockwidget is opened only when the toolbar icon in pressed and not immediately when loading the plugin